### PR TITLE
Symfony 7 preparations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/composer.lock
+/vendor
+/node_modules

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,26 @@
         "php": "^8.1",
         "composer-runtime-api": "2.*",
         "contao/core-bundle": "^4.13 | ^5.0",
-        "symfony/config": "^5.4 || ^6.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/http-kernel": "^5.4 || ^6.0",
-        "symfony/mime": "^5.4 || ^6.0",
         "composer/semver": "^3.3",
-        "knplabs/github-api": "^3.9"
+        "doctrine/dbal": "^3.3",
+        "knplabs/github-api": "^3.9",
+        "symfony/config": "^5.4 || ^6.4 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-client-contracts": "^2.4 || ^3.1",
+        "symfony/http-foundation": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
+        "symfony/mime": "^5.4 || ^6.4 || ^7.0",
+        "symfony/routing": "^5.4 || ^6.4 || ^7.0",
+        "symfony/security-core": "^5.4 || ^6.4 || ^7.0",
+        "symfony/translation-contracts": "^2.3 || ^3.0"
     },
     "require-dev": {
-        "contao/manager-plugin": "^2.0"
+        "contao/manager-plugin": "^2.3.1",
+        "shipmonk/composer-dependency-analyser": "^1.6"
     },
     "conflict": {
         "contao/manager-plugin": "<2.0 || >=3.0"
@@ -41,7 +52,8 @@
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": true
         }
     },
     "extra": {
@@ -49,5 +61,8 @@
             "dev-main": "1.x-dev"
         },
         "contao-manager-plugin": "Oveleon\\ProductInstaller\\ContaoManager\\Plugin"
+    },
+    "scripts": {
+        "depcheck": "@php vendor/bin/composer-dependency-analyser --config=depcheck.php"
     }
 }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,3 +1,0 @@
-oveleon.productinstaller.controller:
-    resource: '@ProductInstaller/src/Controller'
-    type: attribute

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,3 +1,3 @@
 oveleon.productinstaller.controller:
     resource: '@ProductInstaller/src/Controller'
-    type: annotation
+    type: attribute

--- a/depcheck.php
+++ b/depcheck.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+return (new Configuration())
+    ->ignoreUnknownClasses([
+        'Contao\CalendarEventsModel',
+        'Contao\CalendarFeedModel',
+        'Contao\CalendarModel',
+        'Contao\FaqCategoryModel',
+        'Contao\FaqModel',
+        'Contao\NewsArchiveModel',
+        'Contao\NewsModel',
+        'Contao\NewsletterChannelModel',
+        'Contao\NewsletterModel',
+        'Contao\NewsletterRecipientsModel',
+        'closure',
+    ])
+
+    ->ignoreErrorsOnPackage('contao/manager-plugin', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+;

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -24,14 +24,11 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): RouteCollection|null
     {
         return $resolver
-            ->resolve(__DIR__.'/../../config/routes.yaml')
-            ->load(__DIR__.'/../../config/routes.yaml')
-            ;
+            ->resolve('@ProductInstaller/src/Controller')
+            ->load('@ProductInstaller/src/Controller')
+        ;
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -12,6 +12,7 @@ use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Oveleon\ProductInstaller\ProductInstaller;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouteCollection;
 
 class Plugin implements BundlePluginInterface, RoutingPluginInterface
 {
@@ -26,7 +27,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): RouteCollection|null
     {
         return $resolver
             ->resolve(__DIR__.'/../../config/routes.yaml')

--- a/src/Controller/API/Composer/Repository.php
+++ b/src/Controller/API/Composer/Repository.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class to write the "repositories" branch to the composer file.
@@ -24,7 +24,7 @@ class Repository
     public function __construct(
         private readonly Composer $composer,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     #[Route('/set',
@@ -33,7 +33,7 @@ class Repository
     )]
     public function set(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/ContaoManager/Authentication.php
+++ b/src/Controller/API/ContaoManager/Authentication.php
@@ -6,7 +6,7 @@ use Contao\BackendUser;
 use Oveleon\ProductInstaller\ContaoManagerFile;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class to handle authentication with the Contao Manager.
@@ -23,12 +23,12 @@ class Authentication
     public function __construct(
         private readonly ContaoManagerFile $managerFile,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     public function __invoke(): void
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/ContaoManager/Database.php
+++ b/src/Controller/API/ContaoManager/Database.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -28,7 +28,7 @@ class Database
         private readonly ContaoManager $contaoManager,
         private readonly TranslatorInterface $translator,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     #[Route('/check',
@@ -37,7 +37,7 @@ class Database
     )]
     public function check(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -97,7 +97,7 @@ class Database
     )]
     public function migrateStatus(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -145,7 +145,7 @@ class Database
     )]
     public function createMigrate(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -201,7 +201,7 @@ class Database
     )]
     public function startMigrate(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -264,7 +264,7 @@ class Database
     )]
     public function deleteMigrate(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/ContaoManager/Package.php
+++ b/src/Controller/API/ContaoManager/Package.php
@@ -11,7 +11,7 @@ use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -31,7 +31,7 @@ class Package
         private readonly ContaoManager $contaoManager,
         private readonly TranslatorInterface $translator,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -44,7 +44,7 @@ class Package
     )]
     public function installPackage(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/ContaoManager/Session.php
+++ b/src/Controller/API/ContaoManager/Session.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
@@ -38,7 +38,7 @@ class Session
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -47,7 +47,7 @@ class Session
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/ContaoManager/Task.php
+++ b/src/Controller/API/ContaoManager/Task.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -32,7 +32,7 @@ class Task
         private readonly ContaoManager $contaoManager,
         private readonly TranslatorInterface $translator,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     #[Route('/set',
@@ -41,7 +41,7 @@ class Task
     )]
     public function set(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -120,7 +120,7 @@ class Task
     )]
     public function get(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -156,7 +156,7 @@ class Task
     )]
     public function stop(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {
@@ -192,7 +192,7 @@ class Task
     )]
     public function delete(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/Download/DownloadController.php
+++ b/src/Controller/API/Download/DownloadController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -34,7 +34,7 @@ class DownloadController
         private readonly RepositoryDownloader $githubDownloader,
         private readonly TranslatorInterface $translator,
         private readonly ConnectorUtil $connectorUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -60,7 +60,7 @@ class DownloadController
      */
     public function __invoke(): Response
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/AdvertisingController.php
+++ b/src/Controller/API/LicenseConnector/AdvertisingController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -27,7 +27,7 @@ class AdvertisingController
         private readonly TranslatorInterface $translator,
         private readonly RequestStack $requestStack,
         private readonly ConnectorUtil $connectorUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -35,7 +35,7 @@ class AdvertisingController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/InstallerLockController.php
+++ b/src/Controller/API/LicenseConnector/InstallerLockController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Helper functions to edit the installer lock file via the API.
@@ -25,7 +25,7 @@ class InstallerLockController
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly InstallerLock $installerLock,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     #[Route('/remove',
@@ -34,7 +34,7 @@ class InstallerLockController
     )]
     public function remove(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/LicenseConnectorController.php
+++ b/src/Controller/API/LicenseConnector/LicenseConnectorController.php
@@ -7,7 +7,7 @@ use Oveleon\ProductInstaller\Util\ConnectorUtil;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -25,7 +25,7 @@ class LicenseConnectorController
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly ConnectorUtil $connectorUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     #[Route('/config',
@@ -34,7 +34,7 @@ class LicenseConnectorController
     )]
     public function getLicenseConnectors(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/LicenseController.php
+++ b/src/Controller/API/LicenseConnector/LicenseController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -28,7 +28,7 @@ class LicenseController
         private readonly RequestStack $requestStack,
         private readonly TranslatorInterface $translator,
         private readonly ConnectorUtil $connectorUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -36,7 +36,7 @@ class LicenseController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/ProductController.php
+++ b/src/Controller/API/LicenseConnector/ProductController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -30,7 +30,7 @@ class ProductController
         private readonly TranslatorInterface $translator,
         private readonly InstallerLock $installerLock,
         private readonly ConnectorUtil $connectorUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -38,7 +38,7 @@ class ProductController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/LicenseConnector/RegisterProductController.php
+++ b/src/Controller/API/LicenseConnector/RegisterProductController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,7 +29,7 @@ class RegisterProductController
         private readonly TranslatorInterface $translator,
         private readonly ConnectorUtil $connectorUtil,
         private readonly InstallerLock $installerLock,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -37,7 +37,7 @@ class RegisterProductController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/Setup/SetupController.php
+++ b/src/Controller/API/Setup/SetupController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,7 +29,7 @@ class SetupController
         private readonly RequestStack $requestStack,
         private readonly TranslatorInterface $translator,
         private readonly ContentPackageSetup $contentPackageSetup,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -39,7 +39,7 @@ class SetupController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/Setup/SetupInitController.php
+++ b/src/Controller/API/Setup/SetupInitController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -34,7 +34,7 @@ class SetupInitController
         private readonly TranslatorInterface $translator,
         private readonly InstallerLock $installerLock,
         private readonly ArchiveUtil $archiveUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -44,7 +44,7 @@ class SetupInitController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/Controller/API/Upload/UploadController.php
+++ b/src/Controller/API/Upload/UploadController.php
@@ -9,7 +9,7 @@ use Contao\System;
 use Oveleon\ProductInstaller\ProductTaskType;
 use Oveleon\ProductInstaller\Util\ArchiveUtil;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -33,7 +33,7 @@ class UploadController
         protected readonly ContaoFramework $framework,
         protected readonly TranslatorInterface $translator,
         protected readonly ArchiveUtil $archiveUtil,
-        private readonly Security $security,
+        protected TokenStorageInterface $tokenStorage,
     ){}
 
     /**
@@ -41,7 +41,7 @@ class UploadController
      */
     public function __invoke(): JsonResponse
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin)
         {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('product_installer');
         $treeBuilder

--- a/src/EventListener/BackendMenuListener.php
+++ b/src/EventListener/BackendMenuListener.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Oveleon\ProductInstaller\EventListener;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\MenuEvent;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
-/**
- * @ServiceTag("kernel.event_listener", event="contao.backend_menu_build", priority=-255)
- */
+#[AsEventListener(ContaoCoreEvents::BACKEND_MENU_BUILD, priority: -255)]
 class BackendMenuListener
 {
-    public function __construct(private readonly Security $security, protected TranslatorInterface $translator)
-    {}
+    public function __construct(
+        protected TranslatorInterface $translator,
+        protected TokenStorageInterface $tokenStorage,
+    ) {}
 
     public function __invoke(MenuEvent $event): void
     {
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         if (!$user instanceof BackendUser || !$user->isAdmin) {
             return;


### PR DESCRIPTION
### Changes

* Register routes directly to allow symfony 5, 6 and 7 simultaneously 47471b9b3510933c32332c96e494a554090ff025
 
  > type `annotation` and `attribute` are not allowed simultaneously in Symfony 5 and 7

* Usage of TokenStorageInterface instead of deprecated `Symfony/Security` class

  > The Security class has been deprecated in Symfony 6 and does not exist in 7 anymore. The TokenStorageInterface will work for all Symfony versions

* Add return type to getConfigTreeBuilder to fix a Symfony 7 error

* Use EventListener backend attribute to register the backend menu 

* Added dep check

* Added all shadow-dependencies